### PR TITLE
Tweak rate limit delay logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ export const hogql = async <T extends HogQLScalar[][] = HogQLScalar[][]>(
       const rateLimitResetsInSeconds = parseDelayFromThrottledErrorDetail(detail);
 
       if (retryOnRateLimit) {
-        await sleep(rateLimitResetsInSeconds * 1_000);
+        await sleep(rateLimitResetsInSeconds * 2_000);
         return hogql(query, {
           apiKey,
           baseUrl,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cc706a80d0ee904fa05f6ad0de1fd6b75f7bd6b2  | 
|--------|--------|

### Summary:
Doubled the sleep duration in the `hogql` function in `src/index.ts` when retrying after a rate limit error to reduce retry frequency and ease server load.

**Key points**:
- **File**: `src/index.ts`
- **Function**: `hogql`
- **Change**: Doubled the sleep duration from `rateLimitResetsInSeconds * 1_000` to `rateLimitResetsInSeconds * 2_000` when retrying after a rate limit error.
- **Impact**: Reduces retry frequency after rate limiting, potentially easing server load.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Increased the delay time for retrying requests after encountering a rate limit error, enhancing the handling of rate limits and reducing immediate retries.
  
This change aims to improve overall system responsiveness under rate-limiting conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->