### PR TITLE
Fix default base URL in types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export interface HogQLQueryOptions {
   apiKey: string;
 
   /**
-   * The base URL for the PostHog API. Defaults to https://us.posthog.com. Can be overridden to point to EU Cloud (https://eu.posthog.com) or a self-hosted instance.
+   * The base URL for the PostHog API. Defaults to https://api.posthog.com. Can be overridden to point to EU Cloud (https://eu.posthog.com) or a self-hosted instance.
    */
   baseUrl?: string;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0b0f460a0ad82151ab47091984c19c0d0ae6ea4e  | 
|--------|--------|

### Summary:
Updated default base URL in `HogQLQueryOptions` interface documentation.

**Key points**:
- Updated default base URL in `HogQLQueryOptions` interface documentation in `src/index.ts` from `https://us.posthog.com` to `https://api.posthog.com`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the default `baseUrl` for the PostHog API to `https://api.posthog.com`, providing users with the correct endpoint for API interactions.
- **Documentation**
	- Enhanced documentation clarity regarding the `baseUrl` property within the `HogQLQueryOptions` interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->